### PR TITLE
Fixed a bug in displaying a huge amount of health on death

### DIFF
--- a/game_objects/npc.py
+++ b/game_objects/npc.py
@@ -85,7 +85,7 @@ class NPC(GameObject):
                 self.play(self.sound.enemy_attack[self.npc_id])
 
             if random.random() < self.hit_probability:
-                self.player.health -= self.damage
+                self.player.get_damage(self.damage)
                 #
                 self.play(self.sound.player_hurt)
             return True

--- a/player.py
+++ b/player.py
@@ -101,6 +101,9 @@ class Player(Camera):
             npc = self.eng.level_map.npc_map[npc_pos]
             npc.get_damage()
 
+    def get_damage(self, value):
+        self.health = max(self.health - value, 0)
+
     def switch_weapon(self, weapon_id):
         if self.weapons[weapon_id]:
             self.weapon_instance.weapon_id = self.weapon_id = weapon_id


### PR DESCRIPTION
Fixed a bug that caused a character's health value to be less than zero for a second when he died, and a huge value was displayed due to the peculiarities of the health calculation system.